### PR TITLE
dev: antd 5.11.0 ref使用方式改变，修复bug

### DIFF
--- a/packages/ui/table/src/index.tsx
+++ b/packages/ui/table/src/index.tsx
@@ -36,17 +36,18 @@ function Table<RecordType extends Record<string, any>>(
     let locale = {
         ...icloudLocale,
     };
-    let showQuickJumper: false | { goButton: Record<string, any> | null } | undefined = false;
+    let showQuickJumper: false | {
+        goButton?: React.ReactNode | Record<string, any> | null;
+    } | undefined = false;
     if (pagination) {
         locale = {
             ...locale,
             ...(pagination && pagination.locale ? pagination.locale : {}),
         };
         const goButton = <button>{locale.jump_to_confirm}</button>;
-        showQuickJumper = pagination.showQuickJumper && {
-            ...{goButton},
-            ...(typeof pagination.showQuickJumper === 'boolean' ? {} : pagination.showQuickJumper),
-        };
+        showQuickJumper = pagination.showQuickJumper === true || pagination.showQuickJumper === undefined
+            ? {goButton}
+            : pagination.showQuickJumper;
     }
 
     const antdContext = useContext(ConfigProvider.ConfigContext);

--- a/packages/ui/table/src/useTablePaginationStylePatch.tsx
+++ b/packages/ui/table/src/useTablePaginationStylePatch.tsx
@@ -80,8 +80,8 @@ const useTablePaginationStylePatch = (
 
             let paginationDomList: HTMLElement[] = [];
             try {
-            // antd 5.9.4 更新了 ref 的结构，之后的版本这个获取方式会报错
-            // 增加了 rc-table 的 ref， 并多了nativeElement 嵌套结构
+                // antd 5.11.0 修改了 ref 传递方式
+                // 使用了 Proxy 代理，调用 querySelectorAll 方法会出错
                 paginationDomList = [
                     ...domRef.current?.querySelectorAll(`.${prefixCls}${paginationClassName}`) as any,
                 ];


### PR DESCRIPTION
1. 修改dom获取方式。antd 5.11.0 修改了 ref 传递方式，使用了 Proxy 代理，调用 querySelectorAll 方法会出错，报错情况下会从document上直接使用className查找
2. @osui table 默认会显示jumper， antd table默认不会，改了下table的默认行为
