### PR TITLE
Update antd 5.12.5

### DIFF
--- a/packages/ui/affix/package.json
+++ b/packages/ui/affix/package.json
@@ -54,7 +54,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/alert/package.json
+++ b/packages/ui/alert/package.json
@@ -50,7 +50,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/anchor/package.json
+++ b/packages/ui/anchor/package.json
@@ -50,7 +50,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/auto-complete/package.json
+++ b/packages/ui/auto-complete/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/avatar/package.json
+++ b/packages/ui/avatar/package.json
@@ -50,7 +50,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-jest": "^27.2.1",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",

--- a/packages/ui/back-top/package.json
+++ b/packages/ui/back-top/package.json
@@ -53,7 +53,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/badge/package.json
+++ b/packages/ui/badge/package.json
@@ -55,7 +55,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/brand-provider/src/index.tsx
+++ b/packages/ui/brand-provider/src/index.tsx
@@ -47,8 +47,7 @@ const iCloudConfigs: ConfigProviderProps = {
 const BrandProvider: React.FC<React.PropsWithChildren<{
     brand?: Brand;
     theme?: Partial<ThemeConfig>;
-    ConfigProviderProps?: ConfigProviderProps;
-}>> = (
+} & ConfigProviderProps>> = (
     {brand, theme: outerTheme, children, ...ConfigProviderProps}
 ) => {
     const finalTheme = useMemo(
@@ -71,3 +70,5 @@ const BrandProvider: React.FC<React.PropsWithChildren<{
 export const useBrandContext = () => useContext(BrandContext);
 
 export default BrandProvider;
+
+export const osuiThemeConfig = theme;

--- a/packages/ui/breadcrumb/package.json
+++ b/packages/ui/breadcrumb/package.json
@@ -55,7 +55,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/button/package.json
+++ b/packages/ui/button/package.json
@@ -56,7 +56,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "browserslist": "^4.21.5",

--- a/packages/ui/button/src/index.less
+++ b/packages/ui/button/src/index.less
@@ -236,6 +236,7 @@
 
 .@{osui-button-class-prefix} {
     &-flex-center,
+    &-flex-center.@{ant-prefix}-btn,
     &-flex-center .@{ant-prefix}-btn {
         display: inline-flex;
         align-items: center;

--- a/packages/ui/calendar/package.json
+++ b/packages/ui/calendar/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/card/package.json
+++ b/packages/ui/card/package.json
@@ -57,7 +57,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/carousel/package.json
+++ b/packages/ui/carousel/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/cascader/package.json
+++ b/packages/ui/cascader/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/checkbox/package.json
+++ b/packages/ui/checkbox/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/col/package.json
+++ b/packages/ui/col/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/collapse/package.json
+++ b/packages/ui/collapse/package.json
@@ -54,7 +54,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/config-provider/package.json
+++ b/packages/ui/config-provider/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/date-picker/package.json
+++ b/packages/ui/date-picker/package.json
@@ -53,7 +53,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/descriptions/package.json
+++ b/packages/ui/descriptions/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/divider/package.json
+++ b/packages/ui/divider/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/drawer/package.json
+++ b/packages/ui/drawer/package.json
@@ -54,7 +54,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/dropdown/package.json
+++ b/packages/ui/dropdown/package.json
@@ -56,7 +56,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/empty/package.json
+++ b/packages/ui/empty/package.json
@@ -57,7 +57,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/flex-centered/package.json
+++ b/packages/ui/flex-centered/package.json
@@ -54,7 +54,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/form/package.json
+++ b/packages/ui/form/package.json
@@ -61,7 +61,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/gap/package.json
+++ b/packages/ui/gap/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/grid/package.json
+++ b/packages/ui/grid/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/highlight-text/package.json
+++ b/packages/ui/highlight-text/package.json
@@ -53,7 +53,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/image/package.json
+++ b/packages/ui/image/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/input-number/package.json
+++ b/packages/ui/input-number/package.json
@@ -54,7 +54,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/input/package.json
+++ b/packages/ui/input/package.json
@@ -62,7 +62,7 @@
         "@types/lodash": "^4.14.192",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/joyride/package.json
+++ b/packages/ui/joyride/package.json
@@ -55,7 +55,7 @@
         "@types/lodash.merge": "^4.6.7",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/layout/package.json
+++ b/packages/ui/layout/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/list/package.json
+++ b/packages/ui/list/package.json
@@ -50,7 +50,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/markdown/package.json
+++ b/packages/ui/markdown/package.json
@@ -52,7 +52,7 @@
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
         "@types/unist": "^2.0.6",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/mentions/package.json
+++ b/packages/ui/mentions/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/menu/package.json
+++ b/packages/ui/menu/package.json
@@ -53,7 +53,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/message/package.json
+++ b/packages/ui/message/package.json
@@ -54,7 +54,7 @@
         "@types/lodash.partial": "^4.2.6",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/modal/package.json
+++ b/packages/ui/modal/package.json
@@ -54,7 +54,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/notification/package.json
+++ b/packages/ui/notification/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/pagination/package.json
+++ b/packages/ui/pagination/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/popconfirm/package.json
+++ b/packages/ui/popconfirm/package.json
@@ -53,7 +53,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/popover/package.json
+++ b/packages/ui/popover/package.json
@@ -57,7 +57,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/progress/package.json
+++ b/packages/ui/progress/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/quick-edit/package.json
+++ b/packages/ui/quick-edit/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/radio/package.json
+++ b/packages/ui/radio/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/rate/package.json
+++ b/packages/ui/rate/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/result/package.json
+++ b/packages/ui/result/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/row/package.json
+++ b/packages/ui/row/package.json
@@ -48,7 +48,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/segmented/package.json
+++ b/packages/ui/segmented/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/select/package.json
+++ b/packages/ui/select/package.json
@@ -54,7 +54,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/skeleton/package.json
+++ b/packages/ui/skeleton/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/slider/package.json
+++ b/packages/ui/slider/package.json
@@ -54,7 +54,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/space/package.json
+++ b/packages/ui/space/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/spin/package.json
+++ b/packages/ui/spin/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/statistic/package.json
+++ b/packages/ui/statistic/package.json
@@ -54,7 +54,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/steps/package.json
+++ b/packages/ui/steps/package.json
@@ -53,7 +53,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.2.5",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/switch/package.json
+++ b/packages/ui/switch/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/table/package.json
+++ b/packages/ui/table/package.json
@@ -58,7 +58,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/table/src/index.less
+++ b/packages/ui/table/src/index.less
@@ -182,8 +182,6 @@
         order: -10;
         position: absolute;
         width: 336px;
-        display: inline-flex;
-        justify-content: space-between;
     }
 
     .@{ant-prefix}-pagination-item,
@@ -203,6 +201,8 @@
     }
 
     .@{ant-prefix}-pagination-options-size-changer {
+        float: left;
+
         .@{ant-prefix}-select-selector {
             padding: 0 8px;
         }
@@ -215,6 +215,7 @@
     .@{ant-prefix}-pagination-options .@{ant-prefix}-pagination-options-quick-jumper,
     .@{ant-prefix}-pagination-simple-pager {
         color: var(--pagination-prev-next-icon-color);
+        float: right;
 
         input {
             margin: 0 8px;

--- a/packages/ui/table/src/index.tsx
+++ b/packages/ui/table/src/index.tsx
@@ -91,11 +91,8 @@ function Table<RecordType extends Record<string, any>>(
                 ref={domRef}
                 columns={columns}
                 pagination={mergePagination}
-                expandable={{
-                    expandIcon: osuiExpandIcon,
-                    ...(props.expandable ? {expandable: props.expandable} : {}),
-                }}
-                // expandIcon={}
+                // todo 新方式疑似添加了expandIcon，就必须设置 expandedRowRender
+                expandIcon={props.expandIcon || osuiExpandIcon}
                 onChange={handleChange}
             />
         </div>

--- a/packages/ui/table/src/index.tsx
+++ b/packages/ui/table/src/index.tsx
@@ -31,6 +31,7 @@ function Table<RecordType extends Record<string, any>>(
     ref: React.Ref<HTMLDivElement> | undefined
 ) {
     const domRef = useRef<HTMLDivElement>(null);
+    const containerDomRef = useRef<HTMLDivElement>(null);
     const {brand} = useBrandContext();
     const {pagination = {}} = props;
     let locale = {
@@ -53,7 +54,7 @@ function Table<RecordType extends Record<string, any>>(
     const antdContext = useContext(ConfigProvider.ConfigContext);
     const prefixCls = antdContext.getPrefixCls();
 
-    useTablePaginationStylePatch(domRef, prefixCls);
+    useTablePaginationStylePatch(domRef, prefixCls, containerDomRef);
 
     const className = classNames(
         clsPrefix,
@@ -81,7 +82,7 @@ function Table<RecordType extends Record<string, any>>(
     useImperativeHandle(ref, () => (domRef.current as HTMLDivElement));
 
     return (
-        <div className={className}>
+        <div className={className} ref={containerDomRef}>
             <AntdTable
                 {...props}
                 ref={domRef}

--- a/packages/ui/table/src/index.tsx
+++ b/packages/ui/table/src/index.tsx
@@ -47,9 +47,7 @@ function Table<RecordType extends Record<string, any>>(
                         ...icloudLocale,
                         ...(pagination && pagination.locale ? pagination.locale : {}),
                     },
-                    showQuickJumper: pagination.showQuickJumper === true
-                        ? {goButton}
-                        : pagination.showQuickJumper,
+                    showQuickJumper: pagination.showQuickJumper || {goButton},
                 };
             }
             return paginationIn;

--- a/packages/ui/table/src/useCustomHeadIcons.tsx
+++ b/packages/ui/table/src/useCustomHeadIcons.tsx
@@ -98,14 +98,11 @@ const useCustomHeadIcons: <T extends {
                                 onClick={() => onClick(column)}
                                 className={classNames(
                                     {
-                                        // eslint-disable-next-line max-len
-                                        [`${prefixCls}-column-sorter-down`]: !!isSortedItem && isSortedItem.order === DESCEND,
-                                    },
-                                    {
-                                        // eslint-disable-next-line max-len
-                                        [`${prefixCls}-column-sorter-up`]: !!isSortedItem && isSortedItem.order === ASCEND,
-                                    },
-                                    {
+                                        'osui-icon': true,
+                                        [`${prefixCls}-table-column-sorter-down`]:
+                                            !!isSortedItem && isSortedItem.order === DESCEND,
+                                        [`${prefixCls}-table-column-sorter-up`]:
+                                            !!isSortedItem && isSortedItem.order === ASCEND,
                                         active: !!isSortedItem && isSortedItem.order,
                                     }
                                 )}

--- a/packages/ui/table/src/useTablePaginationStylePatch.tsx
+++ b/packages/ui/table/src/useTablePaginationStylePatch.tsx
@@ -34,7 +34,6 @@ const handleAddAndRemove: (
 ) => void = (parentDom, prefixCls) => {
     const pageSizeDom = parentDom.querySelector(`.${prefixCls}${pageSizeClassName}`);
     const quickJumperDom = parentDom.querySelector(`.${prefixCls}${quickJumperClassName}`);
-    // const simplePagerDom = parentDom.querySelector(`.${prefixCls}${simplePagerClassName}`);
 
     const paginationOptionDom = setPaginationOptionsWidth(parentDom, prefixCls);
     const marginLeft = Number(paginationOptionDom?.style?.marginInlineStart?.replace('px', '')) || 16;

--- a/packages/ui/table/src/useTablePaginationStylePatch.tsx
+++ b/packages/ui/table/src/useTablePaginationStylePatch.tsx
@@ -124,8 +124,8 @@ const useTablePaginationStylePatch = (
             return () => {
                 observerList?.map(observer => observer?.disconnect());
             };
-        },
-        []
+        }
+        // []
     );
 };
 

--- a/packages/ui/table/src/useTablePaginationStylePatch.tsx
+++ b/packages/ui/table/src/useTablePaginationStylePatch.tsx
@@ -70,7 +70,8 @@ const mutationObserverConfig = {attributes: true, childList: true, subtree: true
 
 const useTablePaginationStylePatch = (
     domRef: React.MutableRefObject<HTMLElement | null>,
-    prefixCls: string
+    prefixCls: string,
+    containerDomRef: React.MutableRefObject<HTMLElement | null>
 ) => {
     useEffect(
         () => {
@@ -92,7 +93,7 @@ const useTablePaginationStylePatch = (
             try {
                 if (paginationDomList.length === 0) {
                     const className = (domRef.current.className || '').split(' ').map(v => '.' + v).join(' ');
-                    const dom = document.querySelector(className);
+                    const dom = (containerDomRef.current || document)?.querySelector(className);
                     if (dom) {
                         paginationDomList = [
                             ...dom?.querySelectorAll(`.${prefixCls}${paginationClassName}`) as any,
@@ -125,7 +126,6 @@ const useTablePaginationStylePatch = (
                 observerList?.map(observer => observer?.disconnect());
             };
         }
-        // []
     );
 };
 

--- a/packages/ui/tabs/package.json
+++ b/packages/ui/tabs/package.json
@@ -59,7 +59,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/tag/package.json
+++ b/packages/ui/tag/package.json
@@ -57,7 +57,7 @@
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
         "ClockCircleOutlined": "link:@ant-design/icons/ClockCircleOutlined",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/text-overflow-tooltip/package.json
+++ b/packages/ui/text-overflow-tooltip/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/theme-provider/package.json
+++ b/packages/ui/theme-provider/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/time-picker/package.json
+++ b/packages/ui/time-picker/package.json
@@ -54,7 +54,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/timeline/package.json
+++ b/packages/ui/timeline/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/tooltip/package.json
+++ b/packages/ui/tooltip/package.json
@@ -53,7 +53,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/transfer/package.json
+++ b/packages/ui/transfer/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/tree-select/package.json
+++ b/packages/ui/tree-select/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/tree/package.json
+++ b/packages/ui/tree/package.json
@@ -52,7 +52,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/typography/package.json
+++ b/packages/ui/typography/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/upload/package.json
+++ b/packages/ui/upload/package.json
@@ -60,7 +60,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",

--- a/packages/ui/version/package.json
+++ b/packages/ui/version/package.json
@@ -51,7 +51,7 @@
         "@types/jest": "^27.0.0",
         "@types/react-dom": "^17.0.2",
         "@types/react-test-renderer": "^17.0.1",
-        "antd": "^5.8.6",
+        "antd": "^5.12.5",
         "babel-loader": "^8.1.0",
         "babel-merge": "^3.0.0",
         "cpy-cli": "^3.1.1",


### PR DESCRIPTION
1. select 添加范型支持，增加value值是否是数组的判断
2. 修复table的pagination的布局错位问题，dom 的获取方式，更新expandIcon设置方式
3.更新 antd 版本至 5.12.5